### PR TITLE
Cli '--output-prefix' option; improve multitracker output

### DIFF
--- a/cmd/kubedog/main.go
+++ b/cmd/kubedog/main.go
@@ -29,6 +29,7 @@ func main() {
 	var logsSince string
 	var kubeContext string
 	var kubeConfig string
+	var outputPrefix string
 
 	makeTrackerOptions := func(mode string) tracker.Options {
 		// rollout track defaults
@@ -79,6 +80,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVarP(&logsSince, "logs-since", "", "now", "A duration like 30s, 5m, or 2h to start log records from the past. 'all' to show all logs and 'now' to display only new records (default).")
 	rootCmd.PersistentFlags().StringVarP(&kubeContext, "kube-context", "", os.Getenv("KUBEDOG_KUBE_CONTEXT"), "The name of the kubeconfig context to use (can be set with $KUBEDOG_KUBE_CONTEXT).")
 	rootCmd.PersistentFlags().StringVarP(&kubeConfig, "kube-config", "", os.Getenv("KUBEDOG_KUBE_CONFIG"), "Path to the kubeconfig file (can be set with $KUBEDOG_KUBE_CONFIG).")
+	rootCmd.PersistentFlags().StringVarP(&outputPrefix, "output-prefix", "", "", "Arbitrary string which will be prefixed to kubedog output.")
 
 	versionCmd := &cobra.Command{
 		Use: "version",
@@ -94,6 +96,10 @@ func main() {
 		Example: `echo '{"Deployments":[{"ResourceName":"mydeploy","Namespace":"myns"},{"ResourceName":"myresource","Namespace":"myns","FailMode":"HopeUntilEndOfDeployProcess","AllowFailuresCount":3,"SkipLogsForContainers":["two", "three"]}], "StatefulSets":[{"ResourceName":"mysts","Namespace":"myns"}]}' | kubedog multitrack`,
 		Run: func(cmd *cobra.Command, args []string) {
 			init()
+
+			if outputPrefix != "" {
+				logboek.SetPrefix(outputPrefix, logboek.ColorizeNone)
+			}
 
 			specsInput, err := ioutil.ReadAll(os.Stdin)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/flant/kubedog
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/fatih/color v1.7.0
-	github.com/flant/logboek v0.2.3
+	github.com/flant/logboek v0.2.4-0.20190702173639-9a253aa21697
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/google/btree v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/flant/logboek v0.2.3-0.20190626194023-1580e4b6b6d9 h1:3DJ8TgWZfyi0nQt
 github.com/flant/logboek v0.2.3-0.20190626194023-1580e4b6b6d9/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.3 h1:NVc6TEXQeW0NEg0frSEvtw/fL7phnOnfjvjuJktLEUM=
 github.com/flant/logboek v0.2.3/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
+github.com/flant/logboek v0.2.4-0.20190702173639-9a253aa21697 h1:LxPW3KfHxVqnI+hqpwzAl+T0L7cjfMksXuQ6ghQgsM4=
+github.com/flant/logboek v0.2.4-0.20190702173639-9a253aa21697/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=

--- a/pkg/trackers/rollout/multitrack/job.go
+++ b/pkg/trackers/rollout/multitrack/job.go
@@ -56,6 +56,8 @@ func (mt *multitracker) TrackJob(kube kubernetes.Interface, spec MultitrackSpec,
 }
 
 func (mt *multitracker) jobAdded(spec MultitrackSpec, feed job.Feed) error {
+	mt.JobsStatuses[spec.ResourceName] = feed.GetStatus()
+
 	mt.displayResourceTrackerMessageF("job", spec.ResourceName, "added\n")
 
 	return nil
@@ -87,6 +89,13 @@ func (mt *multitracker) jobAddedPod(spec MultitrackSpec, feed job.Feed, podName 
 }
 
 func (mt *multitracker) jobPodLogChunk(spec MultitrackSpec, feed job.Feed, chunk *pod.PodLogChunk) error {
+	controllerStatus := feed.GetStatus()
+	if podStatus, hasKey := controllerStatus.Pods[chunk.PodName]; hasKey {
+		if podStatus.IsReady {
+			return nil
+		}
+	}
+
 	mt.displayResourceLogChunk("job", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
 	return nil
 }

--- a/pkg/trackers/rollout/multitrack/multitrack_display.go
+++ b/pkg/trackers/rollout/multitrack/multitrack_display.go
@@ -72,7 +72,9 @@ func (mt *multitracker) setLogProcess(header string) {
 	}
 }
 
+// resetLogProcess should be called every time something is about to be displayed
 func (mt *multitracker) resetLogProcess() {
+	mt.displayCalled = true
 	if mt.currentLogProcessHeader != "" {
 		logboek.LogProcessEnd(logboek.LogProcessEndOptions{WithoutLogOptionalLn: true, WithoutElapsedTime: true})
 		mt.currentLogProcessHeader = ""
@@ -80,13 +82,11 @@ func (mt *multitracker) resetLogProcess() {
 }
 
 func (mt *multitracker) displayResourceTrackerMessageF(resourceKind, resourceName string, format string, a ...interface{}) {
-	mt.resetLogProcess()
 	resource := fmt.Sprintf("%s/%s", resourceKind, resourceName)
 	mt.debugDisplayMessagesByResource[resource] = append(mt.debugDisplayMessagesByResource[resource], fmt.Sprintf(fmt.Sprintf("%s: %s", resource, format), a...))
 }
 
 func (mt *multitracker) displayResourceEventF(resourceKind, resourceName string, format string, a ...interface{}) {
-	mt.resetLogProcess()
 	resource := fmt.Sprintf("%s/%s", resourceKind, resourceName)
 	mt.debugDisplayMessagesByResource[resource] = append(mt.debugDisplayMessagesByResource[resource], fmt.Sprintf(fmt.Sprintf("%s event: %s", resource, format), a...))
 }
@@ -153,11 +153,18 @@ func (mt *multitracker) displayMultitrackErrorMessageF(format string, a ...inter
 }
 
 func (mt *multitracker) displayStatusProgress() error {
+	displayLn := false
+	if mt.displayCalled {
+		displayLn = true
+	}
+
 	mt.resetLogProcess()
 
-	caption := color.New(color.Bold).Sprint("Status progress")
+	if displayLn {
+		logboek.LogOptionalLn()
+	}
 
-	logboek.LogOptionalLn()
+	caption := color.New(color.Bold).Sprint("Status progress")
 
 	logboek.LogBlock(caption, logboek.LogBlockOptions{WithoutLogOptionalLn: true}, func() {
 		mt.displayDeploymentsStatusProgress()


### PR DESCRIPTION
* Do not print excess newlines when resources are ready immediately.
* Fix multitracker does not show StatefulSet's and DaemonSet's Pods logs.
* Show logs of all Pods till pod reaches ready state (not configurable for now).

fixes #108

![Demo](https://raw.githubusercontent.com/flant/werf-demos/master/kubedog/kubedog-multitrack-with-output-prefix.gif)
