### PR TITLE
More tracking and display modes of operation; show job logs till pod done

### DIFF
--- a/pkg/tracker/daemonset/feed.go
+++ b/pkg/tracker/daemonset/feed.go
@@ -197,7 +197,8 @@ func (f *feed) Track(name, namespace string, kube kubernetes.Interface, opts tra
 			}
 
 		case err := <-errorChan:
-			return fmt.Errorf("ds/%s error: %v", name, err)
+			return err
+
 		case <-doneChan:
 			return nil
 		}

--- a/pkg/tracker/deployment/feed.go
+++ b/pkg/tracker/deployment/feed.go
@@ -212,7 +212,8 @@ func (f *feed) Track(name, namespace string, kube kubernetes.Interface, opts tra
 			}
 
 		case err := <-errorChan:
-			return fmt.Errorf("deploy/%s error: %v", name, err)
+			return err
+
 		case <-doneChan:
 			return nil
 		}

--- a/pkg/tracker/job/feed.go
+++ b/pkg/tracker/job/feed.go
@@ -215,6 +215,7 @@ func (f *feed) Track(name, namespace string, kube kubernetes.Interface, opts tra
 
 		case err := <-errorChan:
 			return err
+
 		case <-doneChan:
 			return nil
 		}

--- a/pkg/tracker/statefulset/feed.go
+++ b/pkg/tracker/statefulset/feed.go
@@ -197,7 +197,8 @@ func (f *feed) Track(name, namespace string, kube kubernetes.Interface, opts tra
 			}
 
 		case err := <-errorChan:
-			return fmt.Errorf("sts/%s error: %v", name, err)
+			return err
+
 		case <-doneChan:
 			return nil
 		}

--- a/pkg/trackers/rollout/multitrack/daemonset.go
+++ b/pkg/trackers/rollout/multitrack/daemonset.go
@@ -64,12 +64,12 @@ func (mt *multitracker) daemonsetAdded(spec MultitrackSpec, feed daemonset.Feed,
 	mt.DaemonSetsStatuses[spec.ResourceName] = feed.GetStatus()
 
 	if ready {
-		mt.displayResourceTrackerMessageF("ds", spec.ResourceName, "appears to be READY\n")
+		mt.displayResourceTrackerMessageF("ds", spec, "appears to be READY")
 
 		return mt.handleResourceReadyCondition(mt.TrackingDaemonSets, spec)
 	}
 
-	mt.displayResourceTrackerMessageF("ds", spec.ResourceName, "added\n")
+	mt.displayResourceTrackerMessageF("ds", spec, "added")
 
 	return nil
 }
@@ -77,37 +77,36 @@ func (mt *multitracker) daemonsetAdded(spec MultitrackSpec, feed daemonset.Feed,
 func (mt *multitracker) daemonsetReady(spec MultitrackSpec, feed daemonset.Feed) error {
 	mt.DaemonSetsStatuses[spec.ResourceName] = feed.GetStatus()
 
-	mt.displayResourceTrackerMessageF("ds", spec.ResourceName, "become READY\n")
+	mt.displayResourceTrackerMessageF("ds", spec, "become READY")
 
 	return mt.handleResourceReadyCondition(mt.TrackingDaemonSets, spec)
 }
 
 func (mt *multitracker) daemonsetFailed(spec MultitrackSpec, feed daemonset.Feed, reason string) error {
-	mt.displayResourceErrorF("ds", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("ds", spec, "%s", reason)
 
 	return mt.handleResourceFailure(mt.TrackingDaemonSets, "ds", spec, reason)
 }
 
 func (mt *multitracker) daemonsetEventMsg(spec MultitrackSpec, feed daemonset.Feed, msg string) error {
-	mt.displayResourceEventF("ds", spec.ResourceName, "%s\n", msg)
-
+	mt.displayResourceEventF("ds", spec, "%s", msg)
 	return nil
 }
 
 func (mt *multitracker) daemonsetAddedReplicaSet(spec MultitrackSpec, feed daemonset.Feed, rs replicaset.ReplicaSet) error {
-	mt.displayResourceTrackerMessageF("ds", spec.ResourceName, "rs/%s added\n", rs.Name)
+	mt.displayResourceTrackerMessageF("ds", spec, "rs/%s added", rs.Name)
 	return nil
 }
 
 func (mt *multitracker) daemonsetAddedPod(spec MultitrackSpec, feed daemonset.Feed, pod replicaset.ReplicaSetPod) error {
-	mt.displayResourceTrackerMessageF("ds", spec.ResourceName, "po/%s added\n", pod.Name)
+	mt.displayResourceTrackerMessageF("ds", spec, "po/%s added", pod.Name)
 	return nil
 }
 
 func (mt *multitracker) daemonsetPodError(spec MultitrackSpec, feed daemonset.Feed, podError replicaset.ReplicaSetPodError) error {
 	reason := fmt.Sprintf("po/%s container/%s: %s", podError.PodName, podError.ContainerName, podError.Message)
 
-	mt.displayResourceErrorF("ds", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("ds", spec, "%s", reason)
 
 	return mt.handleResourceFailure(mt.TrackingDaemonSets, "ds", spec, reason)
 }
@@ -120,7 +119,7 @@ func (mt *multitracker) daemonsetPodLogChunk(spec MultitrackSpec, feed daemonset
 		}
 	}
 
-	mt.displayResourceLogChunk("ds", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
+	mt.displayResourceLogChunk("ds", spec, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), chunk.ContainerLogChunk)
 	return nil
 }
 

--- a/pkg/trackers/rollout/multitrack/deployment.go
+++ b/pkg/trackers/rollout/multitrack/deployment.go
@@ -64,12 +64,12 @@ func (mt *multitracker) deploymentAdded(spec MultitrackSpec, feed deployment.Fee
 	mt.DeploymentsStatuses[spec.ResourceName] = feed.GetStatus()
 
 	if ready {
-		mt.displayResourceTrackerMessageF("deploy", spec.ResourceName, "appears to be READY\n")
+		mt.displayResourceTrackerMessageF("deploy", spec, "appears to be READY")
 
 		return mt.handleResourceReadyCondition(mt.TrackingDeployments, spec)
 	}
 
-	mt.displayResourceTrackerMessageF("deploy", spec.ResourceName, "added\n")
+	mt.displayResourceTrackerMessageF("deploy", spec, "added")
 
 	return nil
 }
@@ -77,18 +77,18 @@ func (mt *multitracker) deploymentAdded(spec MultitrackSpec, feed deployment.Fee
 func (mt *multitracker) deploymentReady(spec MultitrackSpec, feed deployment.Feed) error {
 	mt.DeploymentsStatuses[spec.ResourceName] = feed.GetStatus()
 
-	mt.displayResourceTrackerMessageF("deploy", spec.ResourceName, "become READY\n")
+	mt.displayResourceTrackerMessageF("deploy", spec, "become READY")
 
 	return mt.handleResourceReadyCondition(mt.TrackingDeployments, spec)
 }
 
 func (mt *multitracker) deploymentFailed(spec MultitrackSpec, feed deployment.Feed, reason string) error {
-	mt.displayResourceErrorF("deploy", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("deploy", spec, "%s", reason)
 	return mt.handleResourceFailure(mt.TrackingDeployments, "deploy", spec, reason)
 }
 
 func (mt *multitracker) deploymentEventMsg(spec MultitrackSpec, feed deployment.Feed, msg string) error {
-	mt.displayResourceEventF("deploy", spec.ResourceName, "%s\n", msg)
+	mt.displayResourceEventF("deploy", spec, "%s\n", msg)
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (mt *multitracker) deploymentAddedReplicaSet(spec MultitrackSpec, feed depl
 		return nil
 	}
 
-	mt.displayResourceTrackerMessageF("deploy", spec.ResourceName, "rs/%s added\n", rs.Name)
+	mt.displayResourceTrackerMessageF("deploy", spec, "rs/%s added", rs.Name)
 
 	return nil
 }
@@ -107,7 +107,7 @@ func (mt *multitracker) deploymentAddedPod(spec MultitrackSpec, feed deployment.
 		return nil
 	}
 
-	mt.displayResourceTrackerMessageF("deploy", spec.ResourceName, "po/%s added\n", pod.Name)
+	mt.displayResourceTrackerMessageF("deploy", spec, "po/%s added", pod.Name)
 
 	return nil
 }
@@ -119,7 +119,7 @@ func (mt *multitracker) deploymentPodError(spec MultitrackSpec, feed deployment.
 
 	reason := fmt.Sprintf("po/%s container/%s: %s", podError.PodName, podError.ContainerName, podError.Message)
 
-	mt.displayResourceErrorF("deploy", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("deploy", spec, "%s", reason)
 
 	return mt.handleResourceFailure(mt.TrackingDeployments, "deploy", spec, reason)
 }
@@ -136,7 +136,7 @@ func (mt *multitracker) deploymentPodLogChunk(spec MultitrackSpec, feed deployme
 		}
 	}
 
-	mt.displayResourceLogChunk("deploy", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
+	mt.displayResourceLogChunk("deploy", spec, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), chunk.ContainerLogChunk)
 
 	return nil
 }

--- a/pkg/trackers/rollout/multitrack/job.go
+++ b/pkg/trackers/rollout/multitrack/job.go
@@ -58,7 +58,7 @@ func (mt *multitracker) TrackJob(kube kubernetes.Interface, spec MultitrackSpec,
 func (mt *multitracker) jobAdded(spec MultitrackSpec, feed job.Feed) error {
 	mt.JobsStatuses[spec.ResourceName] = feed.GetStatus()
 
-	mt.displayResourceTrackerMessageF("job", spec.ResourceName, "added\n")
+	mt.displayResourceTrackerMessageF("job", spec, "added")
 
 	return nil
 }
@@ -66,36 +66,35 @@ func (mt *multitracker) jobAdded(spec MultitrackSpec, feed job.Feed) error {
 func (mt *multitracker) jobSucceeded(spec MultitrackSpec, feed job.Feed) error {
 	mt.JobsStatuses[spec.ResourceName] = feed.GetStatus()
 
-	mt.displayResourceTrackerMessageF("job", spec.ResourceName, "succeeded\n")
+	mt.displayResourceTrackerMessageF("job", spec, "succeeded")
 
 	return mt.handleResourceReadyCondition(mt.TrackingJobs, spec)
 }
 
 func (mt *multitracker) jobFailed(spec MultitrackSpec, feed job.Feed, reason string) error {
-	mt.displayResourceErrorF("job", spec.ResourceName, "%s\n", reason)
-
+	mt.displayResourceErrorF("job", spec, "%s", reason)
 	return mt.handleResourceFailure(mt.TrackingJobs, "job", spec, reason)
 }
 
 func (mt *multitracker) jobEventMsg(spec MultitrackSpec, feed job.Feed, msg string) error {
-	mt.displayResourceEventF("job", spec.ResourceName, "%s\n", msg)
+	mt.displayResourceEventF("job", spec, "%s", msg)
 	return nil
 }
 
 func (mt *multitracker) jobAddedPod(spec MultitrackSpec, feed job.Feed, podName string) error {
-	mt.displayResourceTrackerMessageF("job", spec.ResourceName, "po/%s added\n", podName)
+	mt.displayResourceTrackerMessageF("job", spec, "po/%s added", podName)
 	return nil
 }
 
 func (mt *multitracker) jobPodLogChunk(spec MultitrackSpec, feed job.Feed, chunk *pod.PodLogChunk) error {
-	mt.displayResourceLogChunk("job", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
+	mt.displayResourceLogChunk("job", spec, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), chunk.ContainerLogChunk)
 	return nil
 }
 
 func (mt *multitracker) jobPodError(spec MultitrackSpec, feed job.Feed, podError pod.PodError) error {
 	reason := fmt.Sprintf("po/%s container/%s: %s", podError.PodName, podError.ContainerName, podError.Message)
 
-	mt.displayResourceErrorF("job", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("job", spec, "%s", reason)
 
 	return mt.handleResourceFailure(mt.TrackingJobs, "job", spec, reason)
 }

--- a/pkg/trackers/rollout/multitrack/job.go
+++ b/pkg/trackers/rollout/multitrack/job.go
@@ -84,18 +84,10 @@ func (mt *multitracker) jobEventMsg(spec MultitrackSpec, feed job.Feed, msg stri
 
 func (mt *multitracker) jobAddedPod(spec MultitrackSpec, feed job.Feed, podName string) error {
 	mt.displayResourceTrackerMessageF("job", spec.ResourceName, "po/%s added\n", podName)
-
 	return nil
 }
 
 func (mt *multitracker) jobPodLogChunk(spec MultitrackSpec, feed job.Feed, chunk *pod.PodLogChunk) error {
-	controllerStatus := feed.GetStatus()
-	if podStatus, hasKey := controllerStatus.Pods[chunk.PodName]; hasKey {
-		if podStatus.IsReady {
-			return nil
-		}
-	}
-
 	mt.displayResourceLogChunk("job", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
 	return nil
 }

--- a/pkg/trackers/rollout/multitrack/multitrack.go
+++ b/pkg/trackers/rollout/multitrack/multitrack.go
@@ -18,6 +18,13 @@ import (
 	"github.com/flant/kubedog/pkg/tracker/statefulset"
 )
 
+type TrackTerminationMode string
+
+const (
+	WaitUntilResourceReady TrackTerminationMode = "WaitUntilResourceReady"
+	NonBlocking            TrackTerminationMode = "NonBlocking"
+)
+
 type FailMode string
 
 const (
@@ -26,20 +33,19 @@ const (
 	HopeUntilEndOfDeployProcess       FailMode = "HopeUntilEndOfDeployProcess"
 )
 
-type DeployCondition string
-
-const (
-	ControllerIsReady DeployCondition = "ControllerIsReady"
-	PodIsReady        DeployCondition = "PodIsReady"
-	EndOfDeploy       DeployCondition = "EndOfDeploy"
-)
+//type DeployCondition string
+//
+//const (
+//	ControllerIsReady DeployCondition = "ControllerIsReady"
+//	PodIsReady        DeployCondition = "PodIsReady"
+//	EndOfDeploy       DeployCondition = "EndOfDeploy"
+//)
 
 var (
 	ErrFailWholeDeployProcessImmediately = errors.New("fail whole deploy process immediately")
 )
 
 type MultitrackSpecs struct {
-	//Pods         []MultitrackSpec
 	Deployments  []MultitrackSpec
 	StatefulSets []MultitrackSpec
 	DaemonSets   []MultitrackSpec
@@ -50,6 +56,7 @@ type MultitrackSpec struct {
 	ResourceName string
 	Namespace    string
 
+	TrackTerminationMode    TrackTerminationMode
 	FailMode                FailMode
 	AllowFailuresCount      *int
 	FailureThresholdSeconds *int
@@ -60,7 +67,7 @@ type MultitrackSpec struct {
 	SkipLogs                  bool
 	SkipLogsForContainers     []string
 	ShowLogsOnlyForContainers []string
-	ShowLogsUntil             DeployCondition
+	//ShowLogsUntil             DeployCondition TODO
 
 	SkipEvents bool
 }
@@ -74,6 +81,10 @@ func newMultitrackOptions(parentContext context.Context, timeout time.Duration, 
 }
 
 func setDefaultSpecValues(spec *MultitrackSpec) {
+	if spec.TrackTerminationMode == "" {
+		spec.TrackTerminationMode = WaitUntilResourceReady
+	}
+
 	if spec.FailMode == "" {
 		spec.FailMode = FailWholeDeployProcessImmediately
 	}
@@ -86,10 +97,6 @@ func setDefaultSpecValues(spec *MultitrackSpec) {
 	if spec.FailureThresholdSeconds == nil {
 		spec.FailureThresholdSeconds = new(int)
 		*spec.FailureThresholdSeconds = 0
-	}
-
-	if spec.ShowLogsUntil == "" {
-		spec.ShowLogsUntil = PodIsReady
 	}
 }
 
@@ -222,6 +229,11 @@ func (mt *multitracker) Start(kube kubernetes.Interface, specs MultitrackSpecs, 
 		})
 	}
 
+	if err := mt.applyTrackTerminationMode(); err != nil {
+		errorChan <- fmt.Errorf("unable to apply termination mode: %s", err)
+		return
+	}
+
 	go func() {
 		wg.Wait()
 
@@ -253,6 +265,62 @@ func (mt *multitracker) Start(kube kubernetes.Interface, specs MultitrackSpecs, 
 	}()
 }
 
+func (mt *multitracker) applyTrackTerminationMode() error {
+	if mt.isTerminating {
+		return nil
+	}
+
+	shouldContinueTracking := func(name string, spec MultitrackSpec) bool {
+		switch spec.TrackTerminationMode {
+		case WaitUntilResourceReady:
+			// There is at least one active context with wait mode,
+			// so continue tracking without stopping any contexts
+			return true
+
+		case NonBlocking:
+			return false
+
+		default:
+			panic(fmt.Sprintf("unknown TrackTerminationMode %#v", spec.TrackTerminationMode))
+		}
+	}
+
+	var contextsToStop []*multitrackerContext
+
+	for name, ctx := range mt.DeploymentsContexts {
+		if shouldContinueTracking(name, mt.DeploymentsSpecs[name]) {
+			return nil
+		}
+		contextsToStop = append(contextsToStop, ctx)
+	}
+	for name, ctx := range mt.StatefulSetsContexts {
+		if shouldContinueTracking(name, mt.StatefulSetsSpecs[name]) {
+			return nil
+		}
+		contextsToStop = append(contextsToStop, ctx)
+	}
+	for name, ctx := range mt.DaemonSetsContexts {
+		if shouldContinueTracking(name, mt.DaemonSetsSpecs[name]) {
+			return nil
+		}
+		contextsToStop = append(contextsToStop, ctx)
+	}
+	for name, ctx := range mt.JobsContexts {
+		if shouldContinueTracking(name, mt.JobsSpecs[name]) {
+			return nil
+		}
+		contextsToStop = append(contextsToStop, ctx)
+	}
+
+	mt.isTerminating = true
+
+	for _, ctx := range contextsToStop {
+		ctx.CancelFunc()
+	}
+
+	return nil
+}
+
 func (mt *multitracker) runSpecTracker(kind string, spec MultitrackSpec, wg *sync.WaitGroup, contexts map[string]*multitrackerContext, doneChan chan struct{}, errorChan chan error, trackerFunc func(MultitrackSpec) error) {
 	defer wg.Done()
 
@@ -268,6 +336,8 @@ func (mt *multitracker) runSpecTracker(kind string, spec MultitrackSpec, wg *syn
 		errorChan <- mt.formatFailedTrackingResourcesError()
 		mt.isFailed = true
 		return
+	} else if err == context.Canceled {
+		return
 	} else if err != nil {
 		// unknown error
 		errorChan <- fmt.Errorf("%s/%s track failed: %s", kind, spec.ResourceName, err)
@@ -275,18 +345,11 @@ func (mt *multitracker) runSpecTracker(kind string, spec MultitrackSpec, wg *syn
 		return
 	}
 
-	// Cleanup active contexts
-	//for _, contexts := range []map[string]*multitrackerContext{
-	//	mt.DeploymentsContexts,
-	//	mt.StatefulSetsContexts,
-	//	mt.DaemonSetsContexts,
-	//	mt.JobsContexts,
-	//} {
-	//	for _, ctx := range contexts {
-	//		ctx.CancelFunc()
-	//	}
-	//}
-	//doneChan <- struct{}{}
+	if err := mt.applyTrackTerminationMode(); err != nil {
+		errorChan <- fmt.Errorf("unable to apply termination mode: %s", err)
+		mt.isFailed = true
+		return
+	}
 }
 
 type multitracker struct {
@@ -314,8 +377,10 @@ type multitracker struct {
 	JobsStatuses     map[string]job.JobStatus
 	PrevJobsStatuses map[string]job.JobStatus
 
-	mux      sync.Mutex
-	isFailed bool
+	mux sync.Mutex
+
+	isFailed      bool
+	isTerminating bool
 
 	displayCalled                  bool
 	currentLogProcessHeader        string

--- a/pkg/trackers/rollout/multitrack/multitrack_display.go
+++ b/pkg/trackers/rollout/multitrack/multitrack_display.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (mt *multitracker) displayResourceLogChunk(resourceKind string, spec MultitrackSpec, header string, chunk *pod.ContainerLogChunk) {
+	if spec.SkipLogs {
+		return
+	}
+
 	for _, containerName := range spec.SkipLogsForContainers {
 		if containerName == chunk.ContainerName {
 			return

--- a/pkg/trackers/rollout/multitrack/statefulset.go
+++ b/pkg/trackers/rollout/multitrack/statefulset.go
@@ -64,12 +64,12 @@ func (mt *multitracker) statefulsetAdded(spec MultitrackSpec, feed statefulset.F
 	mt.StatefulSetsStatuses[spec.ResourceName] = feed.GetStatus()
 
 	if ready {
-		mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "appears to be READY\n")
+		mt.displayResourceTrackerMessageF("sts", spec, "appears to be READY")
 
 		return mt.handleResourceReadyCondition(mt.TrackingStatefulSets, spec)
 	}
 
-	mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "added\n")
+	mt.displayResourceTrackerMessageF("sts", spec, "added")
 
 	return nil
 }
@@ -77,36 +77,35 @@ func (mt *multitracker) statefulsetAdded(spec MultitrackSpec, feed statefulset.F
 func (mt *multitracker) statefulsetReady(spec MultitrackSpec, feed statefulset.Feed) error {
 	mt.StatefulSetsStatuses[spec.ResourceName] = feed.GetStatus()
 
-	mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "become READY\n")
+	mt.displayResourceTrackerMessageF("sts", spec, "become READY")
 
 	return mt.handleResourceReadyCondition(mt.TrackingStatefulSets, spec)
 }
 
 func (mt *multitracker) statefulsetFailed(spec MultitrackSpec, feed statefulset.Feed, reason string) error {
-	mt.displayResourceErrorF("sts", spec.ResourceName, "%s\n", reason)
-
+	mt.displayResourceErrorF("sts", spec, "%s", reason)
 	return mt.handleResourceFailure(mt.TrackingStatefulSets, "sts", spec, reason)
 }
 
 func (mt *multitracker) statefulsetEventMsg(spec MultitrackSpec, feed statefulset.Feed, msg string) error {
-	mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "%s\n", msg)
+	mt.displayResourceEventF("sts", spec, "%s", msg)
 	return nil
 }
 
 func (mt *multitracker) statefulsetAddedReplicaSet(spec MultitrackSpec, feed statefulset.Feed, rs replicaset.ReplicaSet) error {
-	mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "rs/%s added\n", rs.Name)
+	mt.displayResourceTrackerMessageF("sts", spec, "rs/%s added", rs.Name)
 	return nil
 }
 
 func (mt *multitracker) statefulsetAddedPod(spec MultitrackSpec, feed statefulset.Feed, pod replicaset.ReplicaSetPod) error {
-	mt.displayResourceTrackerMessageF("sts", spec.ResourceName, "po/%s added\n", pod.Name)
+	mt.displayResourceTrackerMessageF("sts", spec, "po/%s added", pod.Name)
 	return nil
 }
 
 func (mt *multitracker) statefulsetPodError(spec MultitrackSpec, feed statefulset.Feed, podError replicaset.ReplicaSetPodError) error {
 	reason := fmt.Sprintf("po/%s container/%s: %s", podError.PodName, podError.ContainerName, podError.Message)
 
-	mt.displayResourceErrorF("sts", spec.ResourceName, "%s\n", reason)
+	mt.displayResourceErrorF("sts", spec, "%s", reason)
 
 	return mt.handleResourceFailure(mt.TrackingStatefulSets, "sts", spec, reason)
 }
@@ -119,7 +118,7 @@ func (mt *multitracker) statefulsetPodLogChunk(spec MultitrackSpec, feed statefu
 		}
 	}
 
-	mt.displayResourceLogChunk("sts", spec.ResourceName, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), spec, chunk.ContainerLogChunk)
+	mt.displayResourceLogChunk("sts", spec, podContainerLogChunkHeader(chunk.PodName, chunk.ContainerLogChunk), chunk.ContainerLogChunk)
 	return nil
 }
 


### PR DESCRIPTION
 * There are 2 TrackTerminationMode values:
     * WaitUntilResourceReady — default, track this resource until it is ready;
     * NonBlocking — track resource only until there are other running resources trackers.
 * Fix: show jobs logs in multitrack till pods are gone.
 * SkipLogs multitracker spec mode implemented
 * ShowServiceMessages mode implemented (false by default): show kubernetes events and other kube service messages in realtime during tracking