### PR TITLE
Fix 'timeout waiting for the condition' in job tracker

### DIFF
--- a/pkg/tracker/deployment/tracker.go
+++ b/pkg/tracker/deployment/tracker.go
@@ -3,7 +3,6 @@ package deployment
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/flant/kubedog/pkg/tracker"
 	"github.com/flant/kubedog/pkg/tracker/debug"
@@ -40,7 +39,6 @@ type PodErrorReport struct {
 
 type Tracker struct {
 	tracker.Tracker
-	LogsFromTime time.Time
 
 	State             tracker.TrackerState
 	Conditions        []string
@@ -89,9 +87,8 @@ func NewTracker(ctx context.Context, name, namespace string, kube kubernetes.Int
 			FullResourceName: fmt.Sprintf("deploy/%s", name),
 			ResourceName:     name,
 			Context:          ctx,
+			LogsFromTime:     opts.LogsFromTime,
 		},
-
-		LogsFromTime: opts.LogsFromTime,
 
 		Added:  make(chan DeploymentStatus, 1),
 		Ready:  make(chan DeploymentStatus, 0),
@@ -424,7 +421,7 @@ func (d *Tracker) runDeploymentInformer() {
 			return false, nil
 		})
 
-		if err != nil {
+		if err := tracker.AdaptInformerError(err); err != nil {
 			d.errors <- err
 		}
 

--- a/pkg/tracker/event/informer.go
+++ b/pkg/tracker/event/informer.go
@@ -108,15 +108,14 @@ func (e *EventInformer) Run() {
 				//	fmt.Printf("> Event: %#v\n", object)
 				//}
 			case watch.Error:
-				err := fmt.Errorf("> Event error: %v", ev.Object)
-				return true, err
+				return true, fmt.Errorf("event watch error: %v", ev.Object)
 			}
 
 			return false, nil
 		})
 
-		if err != nil {
-			e.Errors <- err
+		if err := tracker.AdaptInformerError(err); err != nil {
+			e.Errors <- fmt.Errorf("event informer for %s failed: %s", e.FullResourceName, err)
 		}
 
 		if debug.Debug() {

--- a/pkg/tracker/job/feed.go
+++ b/pkg/tracker/job/feed.go
@@ -81,7 +81,7 @@ func (f *feed) Track(name, namespace string, kube kubernetes.Interface, opts tra
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(parentContext, opts.Timeout)
 	defer cancel()
 
-	job := NewTracker(ctx, name, namespace, kube)
+	job := NewTracker(ctx, name, namespace, kube, opts)
 
 	go func() {
 		err := job.Track()

--- a/pkg/tracker/pod/informer.go
+++ b/pkg/tracker/pod/informer.go
@@ -97,8 +97,8 @@ func (p *PodsInformer) Run() {
 			return false, nil
 		})
 
-		if err != nil {
-			p.Errors <- err
+		if err := tracker.AdaptInformerError(err); err != nil {
+			p.Errors <- fmt.Errorf("%s pods informer error: %s", p.FullResourceName, err)
 		}
 
 		if debug.Debug() {

--- a/pkg/tracker/pod/tracker.go
+++ b/pkg/tracker/pod/tracker.go
@@ -477,8 +477,8 @@ func (pod *Tracker) runInformer() error {
 			return false, nil
 		})
 
-		if err != nil {
-			pod.errors <- err
+		if err := tracker.AdaptInformerError(err); err != nil {
+			pod.errors <- fmt.Errorf("pod/%s informer error: %s", pod.ResourceName, err)
 		}
 
 		if debug.Debug() {

--- a/pkg/tracker/replicaset/informer.go
+++ b/pkg/tracker/replicaset/informer.go
@@ -127,7 +127,7 @@ func (r *ReplicaSetInformer) Run() {
 			return false, nil
 		})
 
-		if err != nil {
+		if err := tracker.AdaptInformerError(err); err != nil {
 			r.Errors <- err
 		}
 

--- a/pkg/tracker/statefulset/tracker.go
+++ b/pkg/tracker/statefulset/tracker.go
@@ -3,7 +3,6 @@ package statefulset
 import (
 	"context"
 	"fmt"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +34,6 @@ type PodErrorReport struct {
 
 type Tracker struct {
 	tracker.Tracker
-	LogsFromTime time.Time
 
 	State      tracker.TrackerState
 	Conditions []string
@@ -81,9 +79,8 @@ func NewTracker(ctx context.Context, name, namespace string, kube kubernetes.Int
 			FullResourceName: fmt.Sprintf("sts/%s", name),
 			ResourceName:     name,
 			Context:          ctx,
+			LogsFromTime:     opts.LogsFromTime,
 		},
-
-		LogsFromTime: opts.LogsFromTime,
 
 		Added:  make(chan StatefulSetStatus, 1),
 		Ready:  make(chan StatefulSetStatus, 0),
@@ -309,7 +306,7 @@ func (d *Tracker) runStatefulSetInformer() {
 			return false, nil
 		})
 
-		if err != nil {
+		if err := tracker.AdaptInformerError(err); err != nil {
 			d.errors <- err
 		}
 

--- a/pkg/tracker/tracker.go
+++ b/pkg/tracker/tracker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -33,6 +35,7 @@ type Tracker struct {
 	ResourceName     string
 	FullResourceName string // full resource name with resource kind (deploy/superapp)
 	Context          context.Context
+	LogsFromTime     time.Time
 
 	StatusGeneration uint64
 }
@@ -55,4 +58,11 @@ func ResourceErrorf(format string, a ...interface{}) error {
 	return &ResourceError{
 		msg: fmt.Sprintf(format, a...),
 	}
+}
+
+func AdaptInformerError(err error) error {
+	if err == wait.ErrWaitTimeout {
+		return nil
+	}
+	return err
 }

--- a/pkg/utils/controller_utils.go
+++ b/pkg/utils/controller_utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +26,7 @@ type ReplicaSetControllerWrapper struct {
 	deployment         *appsv1.Deployment
 	statefulSet        *appsv1.StatefulSet
 	daemonSet          *appsv1.DaemonSet
+	job                *batchv1.Job
 }
 
 func (w *ReplicaSetControllerWrapper) NewReplicaSetTemplate() corev1.PodTemplateSpec {
@@ -66,6 +69,12 @@ func ControllerAccessor(controller interface{}) ControllerMetadata {
 		}
 		w.labelSelector = c.Spec.Selector
 	case *appsv1.DaemonSet:
+		w.replicaSetTemplate = corev1.PodTemplateSpec{
+			ObjectMeta: c.Spec.Template.ObjectMeta,
+			Spec:       c.Spec.Template.Spec,
+		}
+		w.labelSelector = c.Spec.Selector
+	case *batchv1.Job:
 		w.replicaSetTemplate = corev1.PodTemplateSpec{
 			ObjectMeta: c.Spec.Template.ObjectMeta,
 			Spec:       c.Spec.Template.Spec,


### PR DESCRIPTION
Kubedog uses context cancel function to terminate working tracker of subordinary pod's of the resource.

Kubernetes waiting function `watchtools.UntilWithSync` returns 'timeout waiting for the condition' error
when context actually has been cancelled (bad code in the watchtools!).

Kubedog now suppresses 'timeout waiting for the condition' from `watchtools.UntilWithSync`, because kubedog by itself handles timeouts.